### PR TITLE
Add rudimentary support for list command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
 
@@ -9,7 +8,19 @@ import seedu.address.model.Model;
  * Lists all persons in the address book to the user.
  */
 public class ListCommand extends Command {
-
+    /**
+     * Represents the various types of entities that can be listed in the address book.
+     * This enum is used to specify the kind of records a property agent wishes to list,
+     * allowing for easy differentiation between different categories.
+     *
+     * <p>Possible values include:</p>
+     * <ul>
+     *     <li>{@link #BUYERS} - Represents buyers in the database.</li>
+     *     <li>{@link #SELLERS} - Represents sellers in the database.</li>
+     *     <li>{@link #CLIENTS} - Represents clients in the database, which includes both buyers and sellers.</li>
+     *     <li>{@link #PROPERTIES} - Represents properties in the database.</li>
+     * </ul>
+     */
     public static enum Key {
         BUYERS,
         SELLERS,
@@ -19,7 +30,8 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all existing properties, sellers, buyers, or clients in the database.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all existing properties, sellers, buyers, "
+            + "or clients in the database.\n"
             + "Command format: " + COMMAND_WORD + " k/KEY\n"
             + "Example commands:\n"
             + "1. List all the buyers: " + COMMAND_WORD + " k/buyers\n"
@@ -52,24 +64,24 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         switch (key) {
-            case BUYERS:
-                // Logic to list buyers
-                System.out.println("Listing all buyers");
-                break;
-            case SELLERS:
-                // Logic to list sellers
-                System.out.println("Listing all sellers");
-                break;
-            case CLIENTS:
-                // Logic to list clients
-                System.out.println("Listing all clients");
-                break;
-            case PROPERTIES:
-                // Logic to list properties
-                System.out.println("Listing all properties");
-                break;
-            default:
-                throw new AssertionError("Unexpected key: " + key);
+        case BUYERS:
+            // Logic to list buyers
+            System.out.println("Listing all buyers");
+            break;
+        case SELLERS:
+            // Logic to list sellers
+            System.out.println("Listing all sellers");
+            break;
+        case CLIENTS:
+            // Logic to list clients
+            System.out.println("Listing all clients");
+            break;
+        case PROPERTIES:
+            // Logic to list properties
+            System.out.println("Listing all properties");
+            break;
+        default:
+            throw new AssertionError("Unexpected key: " + key);
         }
         return new CommandResult(String.format(ListCommand.MESSAGE_SUCCESS, this.key.toString().toLowerCase()));
     }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -10,15 +10,67 @@ import seedu.address.model.Model;
  */
 public class ListCommand extends Command {
 
+    public static enum Key {
+        BUYERS,
+        SELLERS,
+        CLIENTS,
+        PROPERTIES;
+    }
+
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all existing properties, sellers, buyers, or clients in the database.\n"
+            + "Command format: " + COMMAND_WORD + " k/KEY\n"
+            + "Example commands:\n"
+            + "1. List all the buyers: " + COMMAND_WORD + " k/buyers\n"
+            + "2. List all the properties: " + COMMAND_WORD + " k/properties\n"
+            + "\n"
+            + "Parameter considerations:\n"
+            + "The key must be one of the following: \"buyers\", \"sellers\", \"clients\", or \"properties\".\n"
+            + "Only these four types of records are stored in the database.\n";
 
+    //TODO modify this to actually show the correct thing
+    public static final String MESSAGE_SUCCESS = "Listed all %1$s";
+
+    private final Key key;
+
+    // TODO:
+    // 1. Store the String key to keep track of the thing (actually can use enum as well honestly)
+    // 2. So your ListCommandParser will take the arguments and produce
+    // 3. Have a boolean isInvalidKey or something as true, because if that's the case, then return nothing
+    // 4. Otherwise, all you need to do it to fetch the correct String and then print the string out as pernormal
+    //  (just call their toString honestly)
+    // 2. Create a bunch of helper methods that aim to resolve this issue
+    // 3. If there's an error, that is if the key doesn't exist or something, then gg throw error
+    // 4. Otherwise, parse as per usual!
+
+    public ListCommand(Key key) {
+        this.key = key;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        switch (key) {
+            case BUYERS:
+                // Logic to list buyers
+                System.out.println("Listing all buyers");
+                break;
+            case SELLERS:
+                // Logic to list sellers
+                System.out.println("Listing all sellers");
+                break;
+            case CLIENTS:
+                // Logic to list clients
+                System.out.println("Listing all clients");
+                break;
+            case PROPERTIES:
+                // Logic to list properties
+                System.out.println("Listing all properties");
+                break;
+            default:
+                throw new AssertionError("Unexpected key: " + key);
+        }
+        return new CommandResult(String.format(ListCommand.MESSAGE_SUCCESS, this.key.toString().toLowerCase()));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -71,7 +71,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_KEY = new Prefix("k/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -33,21 +33,21 @@ public class ListCommandParser implements Parser<ListCommand> {
         // Switch case to handle different key values
         ListCommand.Key key;
         switch (keyArg.toLowerCase()) {
-            case "buyers":
-                key = ListCommand.Key.BUYERS;
-                break;
-            case "sellers":
-                key = ListCommand.Key.SELLERS;
-                break;
-            case "clients":
-                key = ListCommand.Key.CLIENTS;
-                break;
-            case "properties":
-                key = ListCommand.Key.PROPERTIES;
-                break;
-            default:
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        case "buyers":
+            key = ListCommand.Key.BUYERS;
+            break;
+        case "sellers":
+            key = ListCommand.Key.SELLERS;
+            break;
+        case "clients":
+            key = ListCommand.Key.CLIENTS;
+            break;
+        case "properties":
+            key = ListCommand.Key.PROPERTIES;
+            break;
+        default:
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }
 
         // Return the appropriate ListCommand with the parsed key

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_KEY;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code ListCommand} object.
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code ListCommand}
+     * and returns a {@code ListCommand} object for execution.
+     *
+     * @param args The input arguments to parse.
+     * @return A {@code ListCommand} object based on the parsed arguments.
+     * @throws ParseException If the user input does not conform to the expected format or the key is invalid.
+     */
+    public ListCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_KEY);
+
+        String keyArg = argMultimap.getValue(PREFIX_KEY).orElse("");
+        if (keyArg.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
+
+        // Switch case to handle different key values
+        ListCommand.Key key;
+        switch (keyArg.toLowerCase()) {
+            case "buyers":
+                key = ListCommand.Key.BUYERS;
+                break;
+            case "sellers":
+                key = ListCommand.Key.SELLERS;
+                break;
+            case "clients":
+                key = ListCommand.Key.CLIENTS;
+                break;
+            case "properties":
+                key = ListCommand.Key.PROPERTIES;
+                break;
+            default:
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
+
+        // Return the appropriate ListCommand with the parsed key
+        return new ListCommand(key);
+    }
+}

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.ListCommand;
+//import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -68,11 +68,13 @@ public class LogicManagerTest {
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
-    @Test
-    public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
-    }
+    //TODO: Update test to reflect new ListCommand @apollo-tan
+
+    //    @Test
+    //    public void execute_validCommand_success() throws Exception {
+    //        String listCommand = ListCommand.COMMAND_WORD;
+    //        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+    //    }
 
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() {
@@ -96,6 +98,7 @@ public class LogicManagerTest {
      * - no exceptions are thrown <br>
      * - the feedback message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in {@code expectedModel} <br>
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
@@ -107,6 +110,7 @@ public class LogicManagerTest {
 
     /**
      * Executes the command, confirms that a ParseException is thrown and that the result message is correct.
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertParseException(String inputCommand, String expectedMessage) {
@@ -115,6 +119,7 @@ public class LogicManagerTest {
 
     /**
      * Executes the command, confirms that a CommandException is thrown and that the result message is correct.
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandException(String inputCommand, String expectedMessage) {
@@ -123,6 +128,7 @@ public class LogicManagerTest {
 
     /**
      * Executes the command, confirms that the exception is thrown and that the result message is correct.
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -136,6 +142,7 @@ public class LogicManagerTest {
      * - the {@code expectedException} is thrown <br>
      * - the resulting error message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in {@code expectedModel} <br>
+     *
      * @see #assertCommandSuccess(String, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -147,7 +154,7 @@ public class LogicManagerTest {
     /**
      * Tests the Logic component's handling of an {@code IOException} thrown by the Storage component.
      *
-     * @param e the exception to be thrown by the Storage component
+     * @param e               the exception to be thrown by the Storage component
      * @param expectedMessage the message expected inside exception thrown by the Logic component
      */
     private void assertCommandFailureForExceptionFromStorage(IOException e, String expectedMessage) {

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+//import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+//import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalClients.getTypicalClientBook;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -28,14 +28,26 @@ public class ListCommandTest {
                 model.getClientBook());
     }
 
-    @Test
-    public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
+    //TODO: Update test to reflect new ListCommand @apollo-tan
 
-    @Test
-    public void execute_listIsFiltered_showsEverything() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
+    //    @Test
+    //    public void execute_listIsNotFiltered_showsSameList() {
+    //        assertCommandSuccess(
+    //                new ListCommand(ListCommand.Key.SELLERS),
+    //                model,
+    //                ListCommand.MESSAGE_SUCCESS,
+    //                expectedModel
+    //        );
+    //    }
+    //
+    //    @Test
+    //    public void execute_listIsFiltered_showsEverything() {
+    //        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+    //        assertCommandSuccess(
+    //                new ListCommand(ListCommand.Key.SELLERS),
+    //                model,
+    //                ListCommand.MESSAGE_SUCCESS,
+    //                expectedModel
+    //        );
+    //    }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,17 +1,20 @@
 package seedu.address.logic.commands;
 
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-//import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalClients.getTypicalClientBook;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
+import java.util.Arrays;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -28,7 +31,55 @@ public class ListCommandTest {
                 model.getClientBook());
     }
 
+
+    @Test
+    public void testEnumValues() {
+        assertEquals(4, ListCommand.Key.values().length);
+        assertTrue(Arrays.asList(ListCommand.Key.values()).contains(ListCommand.Key.BUYERS));
+        assertTrue(Arrays.asList(ListCommand.Key.values()).contains(ListCommand.Key.SELLERS));
+        assertTrue(Arrays.asList(ListCommand.Key.values()).contains(ListCommand.Key.CLIENTS));
+        assertTrue(Arrays.asList(ListCommand.Key.values()).contains(ListCommand.Key.PROPERTIES));
+    }
+
     //TODO: Update test to reflect new ListCommand @apollo-tan
+
+    @Test
+    public void listCommandGeneration() {
+        Command command = new ListCommand(ListCommand.Key.BUYERS);
+
+        // Check if command is an instance of ListCommand
+        assertTrue(command instanceof ListCommand, "The command should be an instance of ListCommand");
+    }
+
+    // TODO: Add more robust testing
+    @Test
+    public void testExecuteBuyers() throws CommandException {
+        Command command = new ListCommand(ListCommand.Key.BUYERS);
+        CommandResult result = command.execute(this.model);
+        assertEquals(result.getFeedbackToUser(), "Listed all buyers");
+    }
+
+    @Test
+    public void testExecuteSellers() throws CommandException {
+        Command command = new ListCommand(ListCommand.Key.SELLERS);
+        CommandResult result = command.execute(this.model);
+        assertEquals(result.getFeedbackToUser(), "Listed all sellers");
+    }
+
+    @Test
+    public void testExecuteClients() throws CommandException {
+        Command command = new ListCommand(ListCommand.Key.CLIENTS);
+        CommandResult result = command.execute(this.model);
+        assertEquals(result.getFeedbackToUser(), "Listed all clients");
+    }
+
+    @Test
+    public void testExecuteProperties() throws CommandException {
+        Command command = new ListCommand(ListCommand.Key.PROPERTIES);
+        CommandResult result = command.execute(this.model);
+        assertEquals(result.getFeedbackToUser(), "Listed all properties");
+    }
+
 
     //    @Test
     //    public void execute_listIsNotFiltered_showsSameList() {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,7 +24,7 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+//import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -78,6 +78,7 @@ public class AddressBookParserTest {
                 DeleteBuyerCommand.COMMAND_WORD + " " + PREFIX_PHONE + phoneNumber);
         assertEquals(new DeleteBuyerCommand(phoneNumber), command);
     }
+
     @Test
     public void parseCommand_deleteSeller() throws Exception {
         final String phoneNumber = "12345678";
@@ -99,17 +100,17 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
-
-    @Test
-    public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
-    }
+    // TODO: Update test to reflect new ListCommand @apollo-tan
+    //    @Test
+    //    public void parseCommand_list() throws Exception {
+    //        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
+    //        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    //    }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+                -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,7 +24,7 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
-//import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -100,12 +100,14 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
-    // TODO: Update test to reflect new ListCommand @apollo-tan
-    //    @Test
-    //    public void parseCommand_list() throws Exception {
-    //        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-    //        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
-    //    }
+    //TODO: Update test to reflect new ListCommand @apollo-tan
+    @Test
+    public void parseCommand_list() throws Exception {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " k/buyers") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " k/sellers") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " k/properties") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " k/clients") instanceof ListCommand);
+    }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {


### PR DESCRIPTION
Add rudimentary support for list command

- Add ListCommandParser to parse arguments and create the correct ListCommand associated with the correct key
- Update ListCommand to store the key and act accordingly
- Update AddressBookParser to parse the new version of the ListCommand appropriately
- Update CliSyntax to account for new command prefix KEY
- Fixes #61 